### PR TITLE
Test Case 3: Publishing to undeclared queue should raise an error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <assertj.version>3.27.3</assertj.version>
         <mockito.version>5.15.2</mockito.version>
         <micrometer.version>1.14.3</micrometer.version>
-        <spring-rabbit.version>3.2.1</spring-rabbit.version>
+        <spring-rabbit.version>3.2.2</spring-rabbit.version>
         <logback.version>1.5.16</logback.version>
 
         <skipTests>false</skipTests>


### PR DESCRIPTION
This test verifies that attempting to publish a message to an undeclared queue using basicPublish() results in an exception or is handled according to the mock framework's error behavior.

 Technique: Error Guessing
 What’s Being Tested: Publishing behavior when the target queue has not been declared
 Expected Result: An exception (e.g., IOException) is thrown, or mock handles it silently
 Actual Result: [Insert actual result — e.g., exception thrown, or allowed silently]
